### PR TITLE
Edited lobster collider so fish and lobster do not overlap

### DIFF
--- a/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
+++ b/Assets/Plugins/FMOD/Cache/Editor/FMODStudioCache.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   Path: Assets/FMODProject/Build/Desktop/Master.strings.bank
   Name: Master.strings
   StudioPath: bank:/Master.strings
-  lastModified: 638775828239399168
+  lastModified: 638769050510397146
   FileSizes:
   - Name: Desktop
     Value: 902
@@ -71,7 +71,7 @@ MonoBehaviour:
   - {fileID: 156869398938411658}
   StringsBanks:
   - {fileID: -3502195618784033538}
-  cacheTime: 638775828239399168
+  cacheTime: 638769050510397146
   cacheVersion: 131623
 --- !u!114 &156869398938411658
 MonoBehaviour:
@@ -88,7 +88,7 @@ MonoBehaviour:
   Path: Assets/FMODProject/Build/Desktop/Master.bank
   Name: Master
   StudioPath: bank:/Master
-  lastModified: 638775828239399168
+  lastModified: 638769050510392107
   FileSizes:
   - Name: Desktop
     Value: 2146944
@@ -135,7 +135,7 @@ MonoBehaviour:
   Path: Assets/FMODProject/Build/Desktop/SFX.bank
   Name: SFX
   StudioPath: bank:/SFX
-  lastModified: 638775828239399168
+  lastModified: 638769034759276794
   FileSizes:
   - Name: Desktop
     Value: 3232

--- a/Assets/Scenes/DEMO.unity
+++ b/Assets/Scenes/DEMO.unity
@@ -2336,7 +2336,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0.67775464, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
@@ -2347,7 +2347,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 2.3555088, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &759684757
 GameObject:


### PR DESCRIPTION
i noticed the fish were going on top of the lobster's head and then getting destroyed -> extended collider so fish & lobster dont overlap